### PR TITLE
style(base): allow quotemarks to be escaped

### DIFF
--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -48,7 +48,7 @@ module.exports = {
     'one-line': [true, 'check-open-brace', 'check-catch', 'check-else', 'check-whitespace'],
     'ordered-imports': [false],
     'prefer-const': true, // 2.1, 13.1
-    quotemark: [true, 'single', 'jsx-double'],
+    quotemark: [true, 'single', 'jsx-double', 'avoid-escape'],
     radix: true, // 22.3
     semicolon: [true, 'never'], // 21.1 exception
     'switch-default': true,


### PR DESCRIPTION
Tools like [Prettier](https://prettier.io/) escape strings with single quotes using double quotes by default. This PR relaxes the requirements for single quotes to allow quotemarks to be escaped.