### PR TITLE
chore(npm): make tslint-config-prettier optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,34 @@ We've also included a separate config for React projects. In your `tsconfig.json
   "extends": ["tslint-config-blvd/react"]
 }
 ```
+
+### Prettier
+
+[Prettier](https://prettier.io/) is an automated code formatter for JavaScript, TypeScript, and other languages.
+
+This TSLint config works alongside Prettier, too. To use it, install Prettier as well as `tslint-config-prettier` to your project.
+
+```bash
+yarn add --dev prettier tslint-config-prettier
+```
+
+Create a `.prettierrc` file. Then add the following configs. This should make Prettier automatically format your code based
+on the blvd guidelines.
+
+```json
+{
+  "semi": false,
+  "tabWidth": 2,
+  "printWidth": 140,
+  "singleQuote": true,
+  "trailingComma": "none"
+}
+```
+
+Then include `tslint-config-prettier` in your project. **IMPORTANT:** You must add `tslint-config-prettier` last in the `extends` array!
+
+```json
+{
+  "extends": ["tslint-config-blvd/react", "tslint-config-prettier"]
+}
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,6 @@ module.exports = {
     getRuleDirectory('tslint-consistent-codestyle'),
     getRuleDirectory('tslint-microsoft-contrib')
   ],
-  extends: ['tslint:recommended', 'tslint-config-prettier'],
+  extends: ['tslint:recommended'],
   rules: Object.assign({}, base.rules)
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "tslint": "^5.9.1"
   },
   "dependencies": {
-    "tslint-config-prettier": "^1.12.0",
     "tslint-consistent-codestyle": "^1.11.1",
     "tslint-eslint-rules": "^4.1.1",
     "tslint-microsoft-contrib": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,10 +1872,6 @@ tslib@^1.0.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
 
-tslint-config-prettier@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.12.0.tgz#bc8504f286ecf42b906f3d1126a093114f5729cc"
-
 tslint-consistent-codestyle@^1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.11.1.tgz#fa39ff5f5f8a25c537bd1e1f50de6190a2f4d70d"


### PR DESCRIPTION
This will make sure that prettier is opt-in.

BREAKING CHANGE: You will have to re-include prettier with this update.